### PR TITLE
Turn off Travis notification to Slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,3 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-
-notifications:
-  webhooks: https://fs-bitbot.herokuapp.com/travis


### PR DESCRIPTION
The Travis notifications to Slack intercepted by bitbot need refactoring, since they're showing the latest commit from this repo instead of `mod-kb-ebsco`. This turns them off until we can revisit bitbot.