### PR TITLE
Don't run mod-kb-ebsco tests before deploying to production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,7 @@ install:
   - bundle install
 
 script:
-  - rubocop
-  - rake spec
+  - echo "tests for the deployment process itself should go here"
 
 before_deploy:
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash > /dev/null; fi


### PR DESCRIPTION
## Purpose
Whenever this build is run, we run our rubocop style checker, and then run the entire mod-kb-ebsco suite

https://travis-ci.org/thefrontside/folio-mod-kb-ebsco-deploy/builds/330868207

But this work isn't necessary however because the test suite is being run as part of the actual repo build. In fact, because master is protected by the test suite on the mod-kb-ebsco repository, it's impossible for any changes to actually be seen by this deployment repo unless they've already run (and passed) the test suite.

## Approach
This removes those checks as entirely redundant so that we can have faster merge-to-deployment times.