### PR TITLE
[DNM] Harden mod-kb-ebsco deployment pipeline

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,13 @@ put_info() ( printf "${BLUE}[INFO]${RESET} $1\n");
 put_info "Pulling new image into container '${KUBE_DEPLOYMENT_CONTAINER_NAME}' on deployment '${KUBE_DEPLOYMENT_NAME}'";
 kubectl config view;
 kubectl config current-context;
+
+# For rolling deploys, we really should be using the explicit tag name and not 'latest'.  However,
+# since this is decoupled from the folio-org pipeline, there aren't many elegant options for getting ahold
+# of that information (short of directly polling dockerhub).  For now, this hack will force a rolling update
+# despite no "real" change in the manifest, since each call to `kubectl set image` below is effectually identical
+# See: https://stackoverflow.com/questions/40366192/kubernetes-how-to-make-deployment-to-update-image
+kubectl set image deployment/${KUBE_DEPLOYMENT_NAME} ${KUBE_DEPLOYMENT_CONTAINER_NAME}=${DOCKER_IMAGE_NAME};
 kubectl set image deployment/${KUBE_DEPLOYMENT_NAME} ${KUBE_DEPLOYMENT_CONTAINER_NAME}=${DOCKER_IMAGE_NAME}:latest;
 
 # variables needed for Okapi registration


### PR DESCRIPTION
**Note** this is being pushed to see if we can get out from under the cryptic disconnect between pr/8 and the ghost of travisci.  for now, don't merge.

Herein lies work dedicated to increasing the reliability of our CD
pipeline for mod-kb-ebsco.  Since deployments to our infrastructure
are decoupled from the build & deploy process of
folio-org/mod-kb-ebsco, there is a long and winding road from the
merge button to our kubernetes cluster.

Bringing the reliability of the pipeline to 100% will require
changes outside the reaches of this repository, but for now this
seeks to serve as a bucket for any improvements we can make in this
neighborhood.

This initial commit augments the deploy script to force a rolling
update on the mod-kb-ebsco deployment whenever a build is fired on
Circle.  This will grab the 'latest' tag from DockerHub, which may not
always be correct.