### PR TITLE
Update mod-kb-ebsco module version to 1.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - OKAPI_EXTERNAL_ADDRESS: https://okapi.frontside.io
       - FOLIO_MODULE_NAME: mod-kb-ebsco
       - FOLIO_TENANT_ID: fs
-      - MODULE_VERSION: 0.1.1
+      - MODULE_VERSION: 1.0.2
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Mod-kb-ebsco was released for Q32018 as noted at 
https://github.com/folio-org/mod-kb-ebsco/releases

As part of release process we updated the mod-kb-ebsco version number

Update deployment script to reflect latest version of mod-kb-ebsco (1.0.2)

It is currently set at 0.1.1

